### PR TITLE
Fix ds4 controller crash

### DIFF
--- a/src/controllers/Dualshock4Controller.ts
+++ b/src/controllers/Dualshock4Controller.ts
@@ -36,10 +36,9 @@ class DualShock4Controller implements Controller {
 				}
 			}, 1000)
 
-			// cleanup if other controller found
+			// cleanup once controller is found
 			race.then(() => {
 				clearInterval(discoveryInterval)
-				this._controller.state.unsubscribe()
 			})
 		})
 	}


### PR DESCRIPTION
The previous logic would cause the command to exit unexpectedly. This still includes the clean-up code, but doesn't unsubscribe from the controller when the race promise is resolved :)